### PR TITLE
Make encoding type nullable (JSDoc)

### DIFF
--- a/lib/zyre.js
+++ b/lib/zyre.js
@@ -252,7 +252,7 @@ class Zyre extends EventEmitter {
   /**
    * Sets the encoding of received messages. Defaults to utf8.
    *
-   * @param {string} encoding - Encoding of messages
+   * @param {?string} encoding - Encoding of messages
    */
   setEncoding(encoding) {
     switch (encoding) {


### PR DESCRIPTION
Request for a little change in the documentation of the code.

According to [JSDoc](http://usejsdoc.org/tags-type.html), nullable types can be marked with a question mark to indicate to users that `null` is allowed.